### PR TITLE
Feature/function components rather than class components

### DIFF
--- a/web/src/Config/AdvancedConfigDialog.tsx
+++ b/web/src/Config/AdvancedConfigDialog.tsx
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Dialog, DialogTitle, DialogContent, Typography, Slider, Grid, Button, TextField, InputAdornment, Select, MenuItem, InputLabel } from '@material-ui/core';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { RootState, dispatch } from '~StateStore/store';
 import { ConfigAction } from '~StateStore/_gen/config_action.ts';
 import { Close } from '@material-ui/icons';
@@ -10,308 +10,190 @@ import { BarAction } from '~StateStore/_gen/bar_action.ts';
 import { LongNoteAction } from '~StateStore/_gen/longNote_action.ts';
 import storageManager from '~storageManager/storageManager';
 
-function mapStateToPlayerWindowProps(state: RootState, props: AdvancedConfigDialogProps) {
-  const {
-    bpm,
-    keys,
-    guideBeat,
-    beatHeight,
-    defaultBarBeat,
-    autoSaveDelay,
-    defaultAppearBeforeBeats,
-  } = state.configState;
-
-  const {
-    open,
-    close,
-  } = props;
-
-  return {
-    bpm,
-    keys,
-    guideBeat,
-    beatHeight,
-    defaultBarBeat,
-    autoSaveDelay,
-    defaultAppearBeforeBeats,
-    open,
-    close,
-  };
-}
-
 export type AdvancedConfigDialogProps = {
   close: () => void;
   open: boolean;
 }
 
-export type AdvancedConfigDialogState = {
-  bpmInput: string;
-  keysInput: string;
-  beatHeightInput: string;
-  defaultBarBeatInput: string;
-  autoSaveDelayInput: string;
-  defaultAppearBeforeBeatsInput: string;
-  storageServiceName: string;
-  storageServiceList: string[];
-};
+export default function AdvancedConfigDialog(props: AdvancedConfigDialogProps) {
+  const bpm = useSelector((state: RootState) => state.configState.bpm);
+  const keys = useSelector((state: RootState) => state.configState.keys);
+  const beatHeight = useSelector((state: RootState) => state.configState.beatHeight);
+  const defaultBarBeat = useSelector((state: RootState) => state.configState.defaultBarBeat);
+  const autoSaveDelay = useSelector((state: RootState) => state.configState.autoSaveDelay);
+  const defaultAppearBeforeBeats = useSelector((state: RootState) => state.configState.defaultAppearBeforeBeats);
 
-class AdvancedConfigDialog extends Component<ReturnType<typeof mapStateToPlayerWindowProps>, AdvancedConfigDialogState>{
-  constructor(props: ReturnType<typeof mapStateToPlayerWindowProps>) {
-    super(props);
+  const guideBeat = useSelector((state: RootState) => state.configState.guideBeat);
 
-    const {
-      bpm,
-      keys,
-      beatHeight,
-      defaultBarBeat,
-      autoSaveDelay,
-      defaultAppearBeforeBeats,
-    } = props;
+  const [bpmInput, setBpmInput] = useState(bpm.toString());
+  const [keysInput, setKeysInput] = useState(keys.toString());
+  const [beatHeightInput, setBeatHeightInput] = useState(beatHeight.toString());
+  const [defaultBarBeatInput, setDefaultBarBeatInput] = useState(defaultBarBeat.toString());
+  const [autoSaveDelayInput, setAutoSaveDelayInput] = useState(autoSaveDelay.toString());
+  const [defaultAppearBeforeBeatsInput, setDefaultAppearBeforeBeatsInput] = useState(defaultAppearBeforeBeats.toString());
 
-    this.state = {
-      bpmInput: bpm.toString(),
-      keysInput: keys.toString(),
-      beatHeightInput: beatHeight.toString(),
-      defaultBarBeatInput: defaultBarBeat.toString(),
-      autoSaveDelayInput: autoSaveDelay.toString(),
-      defaultAppearBeforeBeatsInput: defaultAppearBeforeBeats.toString(),
-      storageServiceName: storageManager.getStorageServiceName(),
-      storageServiceList: storageManager.getStorageServiceList(),
-    };
+  const [storageServiceName, setStorageServiceName] = useState(storageManager.getStorageServiceName());
+  const [storageServiceList, setStorageServiceList] = useState(storageManager.getStorageServiceList());
 
-    this.setBpmInput = this.setBpmInput.bind(this);
-    this.setKeysInput = this.setKeysInput.bind(this);
-    this.setBeatHeightInput = this.setBeatHeightInput.bind(this);
-    this.setDefaultBarBeatInput = this.setDefaultBarBeatInput.bind(this);
-    this.setAutoSaveDelayInput = this.setAutoSaveDelayInput.bind(this);
-    this.setDefaultAppearBeforeBeatInput = this.setDefaultAppearBeforeBeatInput.bind(this);
-  }
+  useEffect(() => setBpmInput(bpm.toString()), [bpm])
+  useEffect(() => setKeysInput(keys.toString()), [keys])
+  useEffect(() => setBeatHeightInput(beatHeight.toString()), [beatHeight])
+  useEffect(() => setDefaultBarBeatInput(defaultBarBeat.toString()), [defaultBarBeat])
+  useEffect(() => setDefaultAppearBeforeBeatsInput(defaultAppearBeforeBeats.toString()), [defaultAppearBeforeBeats])
 
-  public componentWillReceiveProps(nextProps: Readonly<ReturnType<typeof mapStateToPlayerWindowProps>>) {
-    const {
-      bpm,
-      keys,
-      beatHeight,
-      defaultBarBeat,
-      defaultAppearBeforeBeats,
-    } = nextProps;
+  const {
+    close,
+    open,
+  } = props;
 
-    this.setState({
-      bpmInput: bpm.toString(),
-      keysInput: keys.toString(),
-      beatHeightInput: beatHeight.toString(),
-      defaultBarBeatInput: defaultBarBeat.toString(),
-      defaultAppearBeforeBeatsInput: defaultAppearBeforeBeats.toString(),
-    });
-  }
-
-  private setBpmInput(value: string) {
-    this.setState({
-      bpmInput: value,
-    });
-  }
-
-  private setKeysInput(value: string) {
-    this.setState({
-      keysInput: value,
-    });
-  }
-
-  private setBeatHeightInput(value: string) {
-    this.setState({
-      beatHeightInput: value,
-    });
-  }
-
-  private setDefaultBarBeatInput(value: string) {
-    this.setState({
-      defaultBarBeatInput: value,
-    });
-  }
-
-  private setAutoSaveDelayInput(value: string) {
-    this.setState({
-      autoSaveDelayInput: value,
-    });
-  }
-
-  private setDefaultAppearBeforeBeatInput(value: string) {
-    this.setState({
-      defaultAppearBeforeBeatsInput: value,
-    });
-  }
-
-  public render() {
-    const {
-      close,
-      open,
-      guideBeat,
-    } = this.props;
-
-    const {
-      bpmInput,
-      keysInput,
-      beatHeightInput,
-      defaultBarBeatInput,
-      autoSaveDelayInput,
-      defaultAppearBeforeBeatsInput,
-      storageServiceName,
-      storageServiceList,
-    } = this.state;
-
-    const configMap: {
-      name: string,
-      value: string,
-      setValue: (value: string) => void,
-      apply: () => void;
-    }[] = [
-        {
-          name: 'bpm',
-          value: bpmInput,
-          setValue: this.setBpmInput,
-          apply: () => {
-            const value = parseFloat(bpmInput);
-            if (!isNumber(value)) {
-              return;
-            }
-            dispatch(ConfigAction.setBpm(value))
-          },
+  const configMap: {
+    name: string,
+    value: string,
+    setValue: (value: string) => void,
+    apply: () => void;
+  }[] = [
+      {
+        name: 'bpm',
+        value: bpmInput,
+        setValue: setBpmInput,
+        apply: () => {
+          const value = parseFloat(bpmInput);
+          if (!isNumber(value)) {
+            return;
+          }
+          dispatch(ConfigAction.setBpm(value))
         },
-        {
-          name: 'keys',
-          value: keysInput,
-          setValue: this.setKeysInput,
-          apply: () => {
-            const value = parseFloat(keysInput);
-            if (!isNumber(value)) {
-              return;
-            }
+      },
+      {
+        name: 'keys',
+        value: keysInput,
+        setValue: setKeysInput,
+        apply: () => {
+          const value = parseFloat(keysInput);
+          if (!isNumber(value)) {
+            return;
+          }
 
-            const keys = Math.floor(value);
+          const keys = Math.floor(value);
 
-            dispatch(batchActions([
-              ConfigAction.setKeys(keys),
-              BarAction.removeNotesOutOfKeys(keys),
-              LongNoteAction.removeLongNotesOutOfKeys(keys),
-            ]));
-          },
+          dispatch(batchActions([
+            ConfigAction.setKeys(keys),
+            BarAction.removeNotesOutOfKeys(keys),
+            LongNoteAction.removeLongNotesOutOfKeys(keys),
+          ]));
         },
-        {
-          name: 'beatHeight',
-          value: beatHeightInput,
-          setValue: this.setBeatHeightInput,
-          apply: () => {
-            const value = parseFloat(beatHeightInput);
-            if (!isNumber(value)) {
-              return;
-            }
-            dispatch(ConfigAction.setBeatHeight(value))
-          },
+      },
+      {
+        name: 'beatHeight',
+        value: beatHeightInput,
+        setValue: setBeatHeightInput,
+        apply: () => {
+          const value = parseFloat(beatHeightInput);
+          if (!isNumber(value)) {
+            return;
+          }
+          dispatch(ConfigAction.setBeatHeight(value))
         },
-        {
-          name: 'defaultBarBeat',
-          value: defaultBarBeatInput,
-          setValue: this.setDefaultBarBeatInput,
-          apply: () => {
-            const value = parseFloat(defaultBarBeatInput);
-            if (!isNumber(value)) {
-              return;
-            }
-            dispatch(ConfigAction.setDefaultBarBeat(value))
-          },
+      },
+      {
+        name: 'defaultBarBeat',
+        value: defaultBarBeatInput,
+        setValue: setDefaultBarBeatInput,
+        apply: () => {
+          const value = parseFloat(defaultBarBeatInput);
+          if (!isNumber(value)) {
+            return;
+          }
+          dispatch(ConfigAction.setDefaultBarBeat(value))
         },
-        {
-          name: 'autoSaveDelay',
-          value: autoSaveDelayInput,
-          setValue: this.setAutoSaveDelayInput,
-          apply: () => {
-            const value = parseFloat(bpmInput);
-            if (!isNumber(value)) {
-              return;
-            }
-            dispatch(ConfigAction.setAutoSaveDelay(value))
-          },
+      },
+      {
+        name: 'autoSaveDelay',
+        value: autoSaveDelayInput,
+        setValue: setAutoSaveDelayInput,
+        apply: () => {
+          const value = parseFloat(bpmInput);
+          if (!isNumber(value)) {
+            return;
+          }
+          dispatch(ConfigAction.setAutoSaveDelay(value))
         },
-        {
-          name: 'defaultAppearBeforeBeat (beat)',
-          value: defaultAppearBeforeBeatsInput,
-          setValue: this.setDefaultAppearBeforeBeatInput,
-          apply: () => {
-            const value = parseFloat(defaultAppearBeforeBeatsInput);
-            if (!isNumber(value)) {
-              return;
-            }
-            dispatch(ConfigAction.setDefaultAppearBeforeBeats(value))
-          },
+      },
+      {
+        name: 'defaultAppearBeforeBeat (beat)',
+        value: defaultAppearBeforeBeatsInput,
+        setValue: setDefaultAppearBeforeBeatsInput,
+        apply: () => {
+          const value = parseFloat(defaultAppearBeforeBeatsInput);
+          if (!isNumber(value)) {
+            return;
+          }
+          dispatch(ConfigAction.setDefaultAppearBeforeBeats(value))
         },
-    ];
+      },
+  ];
 
-    return (
-      <Dialog
-        onClose={close}
-        open={open}
-      >
-        <DialogTitle>
-          <Grid container alignItems="center">
-            <Grid item xs>
-              <Typography variant="h4">Advanced Config</Typography>
-            </Grid>
-            <Grid item>
-              <Button variant="text" onClick={close}><Close fontSize="large" /></Button>
-            </Grid>
+  return (
+    <Dialog
+      onClose={close}
+      open={open}
+    >
+      <DialogTitle>
+        <Grid container alignItems="center">
+          <Grid item xs>
+            <Typography variant="h4">Advanced Config</Typography>
           </Grid>
-        </DialogTitle>
-        <DialogContent>
-          <Typography gutterBottom>Guide Beat</Typography>
-          <Slider
-            value={Math.log2(guideBeat)}
-            min={-4}
-            step={1}
-            max={1}
-            valueLabelDisplay="auto"
-            valueLabelFormat={(value) => value < 0 ? `1 / ${2 ** -value}` : value}
-            onChange={(_, value) => dispatch(ConfigAction.setGuideBeat(2 ** (value as number)))}
+          <Grid item>
+            <Button variant="text" onClick={close}><Close fontSize="large" /></Button>
+          </Grid>
+        </Grid>
+      </DialogTitle>
+      <DialogContent>
+        <Typography gutterBottom>Guide Beat</Typography>
+        <Slider
+          value={Math.log2(guideBeat)}
+          min={-4}
+          step={1}
+          max={1}
+          valueLabelDisplay="auto"
+          valueLabelFormat={(value) => value < 0 ? `1 / ${2 ** -value}` : value}
+          onChange={(_, value) => dispatch(ConfigAction.setGuideBeat(2 ** (value as number)))}
+        />
+      </DialogContent>
+      {configMap.map(config =>
+        <DialogContent key={config.name}>
+          <TextField
+            fullWidth
+            label={config.name}
+            type="number"
+            value={config.value}
+            onChange={event => config.setValue(event.target.value)}
+            InputProps={{
+              endAdornment: <InputAdornment position="start">
+                <Button onClick={config.apply}>변경</Button>
+              </InputAdornment>,
+            }}
           />
         </DialogContent>
-        {configMap.map(config =>
-          <DialogContent key={config.name}>
-            <TextField
-              fullWidth
-              label={config.name}
-              type="number"
-              value={config.value}
-              onChange={event => config.setValue(event.target.value)}
-              InputProps={{
-                endAdornment: <InputAdornment position="start">
-                  <Button onClick={config.apply}>변경</Button>
-                </InputAdornment>,
-              }}
-            />
-          </DialogContent>
-        )}
-        <DialogContent>
-          <InputLabel shrink id="select-storage-service">Storage Service</InputLabel>
-          <Select
-            onClick={() => { this.setState({ storageServiceList: storageManager.getStorageServiceList() }) }}
-            fullWidth
-            labelId="select-storage-service"
-            value={storageServiceName}
-            onChange={event => {
-              const newStorageServiceName = event.target.value as string;
-              const changed = storageManager.setStorageService(newStorageServiceName);
-              if (changed) {
-                this.setState({
-                  storageServiceName: newStorageServiceName,
-                })
-              }
-            }}
-          >
-            {storageServiceList.map(name => <MenuItem key={name} value={name}>{name}</MenuItem>)}
-          </Select>
-        </DialogContent>
-      </Dialog>
-    );
-  }
+      )}
+      <DialogContent>
+        <InputLabel shrink id="select-storage-service">Storage Service</InputLabel>
+        <Select
+          onClick={() => setStorageServiceList(storageManager.getStorageServiceList())}
+          fullWidth
+          labelId="select-storage-service"
+          value={storageServiceName}
+          onChange={event => {
+            const newStorageServiceName = event.target.value as string;
+            const changed = storageManager.setStorageService(newStorageServiceName);
+            if (changed) {
+              setStorageServiceName(newStorageServiceName);
+            }
+          }}
+        >
+          {storageServiceList.map(name => <MenuItem key={name} value={name}>{name}</MenuItem>)}
+        </Select>
+      </DialogContent>
+    </Dialog>
+  );
 }
-
-export default connect(mapStateToPlayerWindowProps)(AdvancedConfigDialog);

--- a/web/src/Config/PlayerWindow.tsx
+++ b/web/src/Config/PlayerWindow.tsx
@@ -1,5 +1,5 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
 import { RootState, dispatch } from '~StateStore/store';
 import { Slider, Button, CardContent, Grid, Switch, FormControlLabel, IconButton, Typography } from '@material-ui/core';
 import { isArray } from 'util';
@@ -9,35 +9,6 @@ import { ConfigAction } from '~StateStore/_gen/config_action.ts';
 import player from './Player';
 import { convertBarBeatToSecond } from '~utils/bar';
 
-type PlayerWindowProps = ReturnType<typeof mapStateToPlayerWindowProps>
-
-type PlayerWindowState = {
-  volume: number;
-  fileName: string;
-}
-
-function mapStateToPlayerWindowProps(state: RootState) {
-  const {
-    isPlaying,
-    cursor,
-  } = state.playerState;
-
-  const {
-    beats,
-  } = state.barState;
-
-  const {
-    autoScroll,
-  } = state.configState;
-
-  return {
-    isPlaying,
-    cursor,
-    beats,
-    autoScroll,
-  };
-}
-
 function getTimeStringFromSeccond(second: number) {
   const minutes = (second / 60).toFixed(0);
   const seconds = (second % 60).toFixed(0);
@@ -45,143 +16,109 @@ function getTimeStringFromSeccond(second: number) {
   return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
 }
 
-class UnconnectedPlayerWindow extends Component<PlayerWindowProps, PlayerWindowState> {
-  constructor(props: PlayerWindowProps) {
-    super(props);
+export default function PlayerWindow() {
+  const cursor = useSelector((state: RootState) => state.playerState.cursor);
+  const isPlaying = useSelector((state: RootState) => state.playerState.isPlaying);
+  const beats = useSelector((state: RootState) => state.barState.beats);
+  const autoScroll = useSelector((state: RootState) => state.configState.autoScroll);
 
-    this.state = {
-      volume: 0.5,
-      fileName: 'Select file',
-    };
+  const [volume, setVolume] = useState(0.5);
+  const [fileName, setFileName] = useState('Select file');
 
-    this.handleVolumeChange = this.handleVolumeChange.bind(this);
-    this.handleFileButtonClick = this.handleFileButtonClick.bind(this);
-  }
+  const duration = getTimeStringFromSeccond(convertBarBeatToSecond(beats));
+  const currentTime = getTimeStringFromSeccond(convertBarBeatToSecond(cursor.beats));
 
-  private handleVolumeChange(event: React.ChangeEvent<{}>, value: number | number[]) {
-    const volume = isArray(value) ? value[0] : value;
-    Player.setVolume(volume);
-    this.setState({
-      volume,
-    });
-  }
-
-  private handleTimebarChange(event: React.ChangeEvent<{}>, value: number | number[]) {
-    const beat = isArray(value) ? value[0] : value;
-    Player.seek(beat);
-  }
-
-  private handleAutoScrollChange(event: React.ChangeEvent<HTMLInputElement>, checked: boolean) {
-    dispatch(ConfigAction.setAutoScroll(checked));
-  }
-
-  private handleFileButtonClick() {
-    const inputElement = document.createElement('input');
-    inputElement.style.display = 'none';
-    inputElement.type = 'file';
-    inputElement.click();
-    inputElement.onchange = event => {
-      const target = event.target as HTMLInputElement;
-      if (!target) {
-        return;
-      }
-      const file = target.files ? target.files[0] : null;
-      if (!file) {
-        return;
-      }
-      this.setState({ fileName: file.name });
-      player.setAudioSource(URL.createObjectURL(file));
-    }
-  }
-
-  public render() {
-    const {
-      volume,
-      fileName,
-    } = this.state;
-
-    const {
-      cursor,
-      isPlaying,
-      beats,
-      autoScroll,
-    } = this.props;
-
-    const duration = getTimeStringFromSeccond(convertBarBeatToSecond(beats));
-    const currentTime = getTimeStringFromSeccond(convertBarBeatToSecond(cursor.beats));
-
-    return (
-      <CardContent>
-        <Grid container alignItems={'center'}>
-          <Grid item xs={12}>
-            <Button
-              onClick={this.handleFileButtonClick}
-              variant="contained"
-              color='primary'
-              fullWidth
-            >{fileName}</Button>
+  return (
+    <CardContent>
+      <Grid container alignItems={'center'}>
+        <Grid item xs={12}>
+          <Button
+            onClick={() => {
+              const inputElement = document.createElement('input');
+              inputElement.style.display = 'none';
+              inputElement.type = 'file';
+              inputElement.click();
+              inputElement.onchange = event => {
+                const target = event.target as HTMLInputElement;
+                if (!target) {
+                  return;
+                }
+                const file = target.files ? target.files[0] : null;
+                if (!file) {
+                  return;
+                }
+                setFileName(file.name);
+                player.setAudioSource(URL.createObjectURL(file));
+              }
+            }}
+            variant="contained"
+            color='primary'
+            fullWidth
+          >{fileName}</Button>
+        </Grid>
+        <Grid container spacing={1} alignItems={'center'}>
+          <Grid item>
+            <IconButton onClick={Player.togglePlay}>
+              {isPlaying ? <Pause /> : <PlayArrow />}
+            </IconButton>
           </Grid>
-          <Grid container spacing={1} alignItems={'center'}>
+          <Grid item>
+            <Typography>
+              {currentTime}
+            </Typography>
+          </Grid>
+          <Grid item xs>
+            <Slider
+              min={0}
+              max={beats}
+              step={0.001}
+              value={cursor.beats}
+              onChange={(event, value) => {
+                const beat = isArray(value) ? value[0] : value;
+                Player.seek(beat);
+              }}
+            />
+          </Grid>
+          <Grid item>
+            <Typography>
+              {duration}
+            </Typography>
+          </Grid>
+        </Grid>
+        <Grid item xs>
+          <FormControlLabel
+            control={<Switch
+              color="primary"
+              checked={autoScroll}
+              onChange={(event, checked) => dispatch(ConfigAction.setAutoScroll(checked))}
+            />}
+            label="Auto Scroll"
+            labelPlacement="start"
+          />
+        </Grid>
+        <Grid item xs={4}>
+          <Grid container alignItems={'center'}>
             <Grid item>
-              <IconButton onClick={Player.togglePlay}>
-                {isPlaying ? <Pause /> : <PlayArrow />}
+              <IconButton>
+                <VolumeUp />
               </IconButton>
-            </Grid>
-            <Grid item>
-              <Typography>
-                {currentTime}
-              </Typography>
             </Grid>
             <Grid item xs>
               <Slider
                 min={0}
-                max={beats}
+                max={1}
                 step={0.001}
-                value={cursor.beats}
-                onChange={this.handleTimebarChange}
+                value={volume}
+                onChange={(event, value) => {
+                  const volume = isArray(value) ? value[0] : value;
+                  Player.setVolume(volume);
+                  setVolume(volume);
+                }}
               />
-            </Grid>
-            <Grid item>
-              <Typography>
-                {duration}
-              </Typography>
-            </Grid>
-          </Grid>
-          <Grid item xs>
-            <FormControlLabel
-              control={<Switch
-                color="primary"
-                checked={autoScroll}
-                onChange={this.handleAutoScrollChange}
-              />}
-              label="Auto Scroll"
-              labelPlacement="start"
-            />
-          </Grid>
-          <Grid item xs={4}>
-            <Grid container alignItems={'center'}>
-              <Grid item>
-                <IconButton>
-                  <VolumeUp />
-                </IconButton>
-              </Grid>
-              <Grid item xs>
-                <Slider
-                  min={0}
-                  max={1}
-                  step={0.001}
-                  value={volume}
-                  onChange={this.handleVolumeChange}
-                />
-              </Grid>
             </Grid>
           </Grid>
         </Grid>
-      </CardContent>
-    );
-  }
+      </Grid>
+    </CardContent>
+  );
 }
-
-const PlayerWindow = connect(mapStateToPlayerWindowProps)(UnconnectedPlayerWindow);
-
-export default PlayerWindow;


### PR DESCRIPTION
```
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.
```
Due to this message, Rework unnecessary class component to function component.
`componentWillReceiveProps()` functions are replaced with function component's hook `useEffect()`